### PR TITLE
Improving escape values control on quality report

### DIFF
--- a/decoration/azuredevops/models/template_model.go
+++ b/decoration/azuredevops/models/template_model.go
@@ -21,10 +21,10 @@ type TemplateModel struct {
 	pullRequest                string `dummy:"pullrequest"`
 	status                     string `dummy:"status"`
 	statusColor                string `dummy:"status-color"`
-	coverage                   string `dummy:"cov"`
+	coverage                   string `dummy:"cov" escape:"true"`
 	coverageStatus             string `dummy:"cov-status"`
 	coverageStatusColor        string `dummy:"cov-status-color"`
-	duplication                string `dummy:"dup"`
+	duplication                string `dummy:"dup" escape:"true"`
 	duplicationStatus          string `dummy:"dup-status"`
 	duplicationStatusColor     string `dummy:"dup-status-color"`
 	reliabilityStatus          string `dummy:"rel-status"`

--- a/decoration/template/engine/dummy/engine_test.go
+++ b/decoration/template/engine/dummy/engine_test.go
@@ -53,6 +53,38 @@ func Test_dummyEngine_ProcessTemplate(t *testing.T) {
 	}
 }
 
+func Test_dummyEngine_ProcessTemplate_WithEscape(t *testing.T) {
+	eng := NewEngine()
+	got, _ := eng.ProcessTemplate("Value1 = \"${field1}\"\nValue2 = \"${field2}\"", struct {
+		field1 string `dummy:"field1"`
+		field2 string `dummy:"field2" escape:"true"`
+	}{
+		field1: "value1",
+		field2: "value2 test with escape",
+	})
+
+	want := "Value1 = \"value1\"\nValue2 = \"value2%20test%20with%20escape\""
+	if got != want {
+		t.Errorf("Result invalid, want \"%s\" but got \"%s\"", want, got)
+	}
+}
+
+func Test_dummyEngine_ProcessTemplate_WithoutEscape(t *testing.T) {
+	eng := NewEngine()
+	got, _ := eng.ProcessTemplate("Value1 = \"${field1}\"\nValue2 = \"${field2}\"", struct {
+		field1 string `dummy:"field1"`
+		field2 string `dummy:"field2"`
+	}{
+		field1: "value1",
+		field2: "value2 test without escape",
+	})
+
+	want := "Value1 = \"value1\"\nValue2 = \"value2 test without escape\""
+	if got != want {
+		t.Errorf("Result invalid, want \"%s\" but got \"%s\"", want, got)
+	}
+}
+
 func Test_dummyEngine_ProcessTemplate_WithEmptyTemplate_ShouldReturnError(t *testing.T) {
 	eng := NewEngine()
 	_, err := eng.ProcessTemplate("", struct{}{})
@@ -110,9 +142,18 @@ func Test_dummyEngine_ProcessTemplate_WithInvalidDataSource_ShouldNotReturnValue
 	}
 }
 
-func Test_processDataSourceField_ShouldReturnExpectedValue(t *testing.T) {
-	got := processDataSourceField("test", "testing-message", "Testing message: \"${test}\"")
-	want := "Testing message: \"testing-message\""
+func Test_processDataSourceField_WithEscape_ShouldReturnExpectedValue(t *testing.T) {
+	got := processDataSourceField("test", "Hi, i'm testing here", "Testing message: \"${test}\"", true)
+	want := "Testing message: \"Hi%2C%20i%27m%20testing%20here\""
+
+	if got != want {
+		t.Errorf("Should process right value. Got \"%s\" but want \"%s\"", got, want)
+	}
+}
+
+func Test_processDataSourceField_WithoutEscape_ShouldReturnExpectedValue(t *testing.T) {
+	got := processDataSourceField("test", "Hi, i'm testing here", "Testing message: \"${test}\"", false)
+	want := "Testing message: \"Hi, i'm testing here\""
 
 	if got != want {
 		t.Errorf("Should process right value. Got \"%s\" but want \"%s\"", got, want)


### PR DESCRIPTION
Now you can use the tag 'escape:"true"' to specify escaped fields on template model